### PR TITLE
Deconflict clj-http.client/update with clojure.core/update

### DIFF
--- a/src/ring_curl/clj_http.clj
+++ b/src/ring_curl/clj_http.clj
@@ -1,6 +1,6 @@
 (ns ring-curl.clj-http
   (:require [clj-http.client :refer :all])
-  (:refer-clojure :exclude [get]))
+  (:refer-clojure :exclude [get update]))
 
 (def middleware
   [wrap-query-params


### PR DESCRIPTION
I ran into an issue where a warning is printed when requiring `ring-curl.clj-http` because `clj-http.client` is referred in and `clj-http.client/update` replaces `clojure.core/update`.

This PR fixes it for me.